### PR TITLE
Fixed nav link colors when selected and hover

### DIFF
--- a/src/components/NavMenu.tsx
+++ b/src/components/NavMenu.tsx
@@ -45,7 +45,7 @@ export const NavMenu = () => {
     <div className="absolute bottom-4 left-1/2 z-50 flex -translate-x-1/2 gap-x-2">
       <ul className="menu rounded-box menu-horizontal bg-base-200">
         {LINKS.map((link) => (
-          <li key={link.href} className={cn("bg-transparent")}>
+          <li key={link.href} className="bg-transparent">
             <div>
               <Link
                 href={link.href}
@@ -61,7 +61,7 @@ export const NavMenu = () => {
       </ul>
       <div className="tooltip" data-tip="Logout">
         <button
-          className={cn("btn btn-square", "rounded-2xl")}
+          className="btn btn-square rounded-2xl"
           onClick={() => void signOut({ callbackUrl: "/" })}
         >
           <FiLogOut />

--- a/src/components/NavMenu.tsx
+++ b/src/components/NavMenu.tsx
@@ -46,7 +46,7 @@ export const NavMenu = () => {
       <ul className="menu rounded-box menu-horizontal bg-base-200">
         {LINKS.map((link) => (
           <li key={link.href} className="bg-transparent">
-            <div>
+            <span>
               <Link
                 href={link.href}
                 className={cn({
@@ -55,7 +55,7 @@ export const NavMenu = () => {
               >
                 {link.icon}
               </Link>
-            </div>
+            </span>
           </li>
         ))}
       </ul>

--- a/src/components/NavMenu.tsx
+++ b/src/components/NavMenu.tsx
@@ -45,13 +45,17 @@ export const NavMenu = () => {
     <div className="absolute bottom-4 left-1/2 z-50 flex -translate-x-1/2 gap-x-2">
       <ul className="menu rounded-box menu-horizontal bg-base-200">
         {LINKS.map((link) => (
-          <li
-            key={link.href}
-            className={cn("", {
-              "text-accent": activePage === link.href.slice(1),
-            })}
-          >
-            <Link href={link.href}>{link.icon}</Link>
+          <li key={link.href} className={cn("bg-transparent")}>
+            <div>
+              <Link
+                href={link.href}
+                className={cn({
+                  "text-accent": activePage === link.href.slice(1),
+                })}
+              >
+                {link.icon}
+              </Link>
+            </div>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
Fixes for https://github.com/dtran421/home-hub-v2/issues/8

- Keep active color for navbar icons
- Remove background on navbar icons after selected